### PR TITLE
Fix copyright in Settings Info tab

### DIFF
--- a/src/modules/utils/modals/settings/settings.html
+++ b/src/modules/utils/modals/settings/settings.html
@@ -369,7 +369,7 @@
                 </div>
 
                 <div class="row flex-row row-style solid-border">
-                    <div class="footnote-1 basic-500">&copy; 2019 Waves Platform</div>
+                    <div class="footnote-1 basic-500" w-i18n-ns="app.welcome" w-i18n="welcome.copyright"></div>
                     <div><span class="waves-logo"></span></div>
                 </div>
             </w-step>


### PR DESCRIPTION
Coryright information is wrong in the settings currently:
![Screenshot_20200324_024118](https://user-images.githubusercontent.com/2538022/77381430-2a3a6b80-6d7e-11ea-9c6e-bbcffa9850fa.png)

This commit changes it to `© 2020 Turtle Network`

One question though before merging. Is it ok to import and use the `copyright` field from `app.welcome.json`? Or should there be a new entry created in a different json?

The previous version had the copyright hardcoded, which I guess we want to avoid.