### PR TITLE
Update links to PrivacyPolicy/TermsAndConditions and make them dynamic

### DIFF
--- a/configs/stagenet.json
+++ b/configs/stagenet.json
@@ -18,7 +18,7 @@
   "wavesGateway": "https://gw-stagenet.wavesplatform.com/",
   "support": "support@turtlenetwork.eu",
   "termsAndConditions": "https://docs.turtlenetwork.eu/files/placeholder.pdf",
-  "privacyPolicy": "https://wavesplatform.com/files/docs/Waves_privacy_policy.pdf",
+  "privacyPolicy": "https://docs.turtlenetwork.eu/files/placeholder.pdf",
   "nodeList": "http://dev.pywaves.org/testnet/generators/",
   "tokensNameListUrl": "https://raw.githubusercontent.com/wavesplatform/waves-community/master/Prominent%20token%20name%20list.csv",
   "scamListUrl": "https://raw.githubusercontent.com/wavesplatform/waves-community/master/Scam%20tokens%20according%20to%20the%20opinion%20of%20Waves%20Community.csv",

--- a/configs/testnet.json
+++ b/configs/testnet.json
@@ -21,7 +21,7 @@
   },
   "support": "https://support.turtlenetwork.eu",
   "termsAndConditions": "https://docs.turtlenetwork.eu/files/placeholder.pdf",
-  "privacyPolicy": "https://wavesplatform.com/files/docs/Waves_privacy_policy.pdf",
+  "privacyPolicy": "https://docs.turtlenetwork.eu/files/placeholder.pdf",
   "nodeList": "http://statistics.turtlenetwork.eu/testnet/generators/",
   "tokensNameListUrl": "https://raw.githubusercontent.com/BlackTurtle123/TN-community/master/Prominent%20token%20name%20list.csv",
   "scamListUrl": "https://raw.githubusercontent.com/BlackTurtle123/TN-community/master/scam-v2.csv",

--- a/src/modules/ui/directives/footer/Footer.js
+++ b/src/modules/ui/directives/footer/Footer.js
@@ -32,6 +32,8 @@
              * @type {string}
              */
             _toasterMobilesStorageKey = 'toasterMobilesHidden';
+            privacyPolicy = WavesApp.network.privacyPolicy;
+            termsAndConditionsLink = WavesApp.network.termsAndConditions;
 
             constructor() {
                 super();

--- a/src/modules/ui/directives/footer/footer.html
+++ b/src/modules/ui/directives/footer/footer.html
@@ -68,9 +68,9 @@
                 <div class="footer__title" w-i18n="welcome.legal"></div>
                 <a w-analytics event="'Footer Privacy Policy Click'"
                    event-target="'ui'"
-                   class="footer__link" w-i18n="welcome.privacyPolicy" target="_blank" rel="noopener noreferrer" href="https://docs.turtlenetwork.eu/files/placeholder.pdf"></a>
+                   class="footer__link" w-i18n="welcome.privacyPolicy" target="_blank" rel="noopener noreferrer" href="{{::$ctrl.privacyPolicy}}"></a>
                 <a w-analytics event="'Footer Terms of use Click'"
-                   event-target="'ui'"class="footer__link" w-i18n="welcome.termsOfUse" target="_blank" rel="noopener noreferrer" href="https://docs.turtlenetwork.eu/files/placeholder.pdf"></a>
+                   event-target="'ui'"class="footer__link" w-i18n="welcome.termsOfUse" target="_blank" rel="noopener noreferrer" href="{{::$ctrl.termsAndConditionsLink}}"></a>
             </div>
 
             <div class="footer__right-item">


### PR DESCRIPTION
Updated  PrivacyPolicy link in `stagenet.json` and `testnet.json`

Footer uses dynamic values now instead of hardcoded, so in the future it will only need to be changed in one place :)

Affected values by this change:
![settingsprivacy](https://user-images.githubusercontent.com/2538022/77422625-16b6f100-6dce-11ea-95cf-4d78e99bc1c7.png)
![footerprivacy](https://user-images.githubusercontent.com/2538022/77422634-19b1e180-6dce-11ea-99b2-61b010b8ab7e.png)
