### PR TITLE
Use terminology 'Get started' instead of 'Create account'

### DIFF
--- a/locale/en/app.welcome.json
+++ b/locale/en/app.welcome.json
@@ -174,7 +174,7 @@
 
         "copyrightVordex": "© 2019 VORDEX",
 
-        "createAccount": "Create account",
+        "createAccount": "Get started",
 
         "createToken": "Create token",
 


### PR DESCRIPTION
This changes the "Create account" button description to "Get started".

The new terminology is more fitting for users that plan to import an existing account, instead of creating a new one.
While it is also welcoming for new users who want to set up their first account.

End result:
![image](https://user-images.githubusercontent.com/2538022/77498181-596cdd80-6e4f-11ea-8947-b1f6be40a23f.png)
