### PR TITLE
Depositing to TN comes from WAVES client

### DIFF
--- a/src/modules/utils/modals/receive/receiveCryptocurrency/receive-cryptocurrency.html
+++ b/src/modules/utils/modals/receive/receiveCryptocurrency/receive-cryptocurrency.html
@@ -44,9 +44,13 @@
         <div class="body-2 basic-900 margin-05" ng-if="!$ctrl.gatewayServerError  && $ctrl.gatewayType !== 'tunnel'">
             <span w-i18n="modal.deposit.copyAndShare"></span>
             <w-help-icon>
-                <div class="help-icon__row headline-3">
+                <div class="help-icon__row headline-3" ng-if="$ctrl.asset.displayName !== 'TN'">
                     <span w-i18n="modal.deposit.helpDescrTitle"
                     params="{  assetTicker: $ctrl.asset.displayName  }"></span>
+                </div>
+                <div class="help-icon__row headline-3" ng-if="$ctrl.asset.displayName === 'TN'">
+                    <span w-i18n="modal.deposit.helpDescrTitle"
+                    params="{  assetTicker: 'WAVES'  }"></span>
                 </div>
                 <div class="help-icon__row">
                     <span w-i18n="modal.deposit.helpDescrText"></span>


### PR DESCRIPTION
fix #133 again

According to the input from @BlackTurtle123
![image](https://user-images.githubusercontent.com/16037736/81576970-2fdd2680-93a9-11ea-9535-4df66c3aa1b1.png)

When depositing to TN, it comes from the users WAVES wallet.

Thus, in the new commit, 'TN' will be replaced by 'WAVES' in the info box for the TN Gateway.